### PR TITLE
Prevent php exception by wrong return type

### DIFF
--- a/Pimcore/ObjectManager.php
+++ b/Pimcore/ObjectManager.php
@@ -166,8 +166,8 @@ final class ObjectManager implements \Doctrine\Persistence\ObjectManager
     {
         $id = spl_object_hash($resource);
 
-        if (method_exists($resource, 'getId')) {
-            $id = $resource->getId() ?? $id;
+        if (method_exists($resource, 'getId') && $resource->getId()) {
+            $id = $resource->getId();
         }
 
         return $id;

--- a/Pimcore/ObjectManager.php
+++ b/Pimcore/ObjectManager.php
@@ -167,7 +167,7 @@ final class ObjectManager implements \Doctrine\Persistence\ObjectManager
         $id = spl_object_hash($resource);
 
         if (method_exists($resource, 'getId')) {
-            $id = $resource->getId();
+            $id = $resource->getId() ?? $id;
         }
 
         return $id;


### PR DESCRIPTION
When creating an object the $id was overwritten in the getResourceId method and set to null. This created a php exception and breaks the code.
This code change will prevent that by checking if the id of the resource object is not null.